### PR TITLE
Morse Translator Punctuation Support

### DIFF
--- a/src/actionHandlers/onMorseTranslate/const.ts
+++ b/src/actionHandlers/onMorseTranslate/const.ts
@@ -1,13 +1,13 @@
-import { ALPHABETICAL_CHARS, DECIMAL_NUMBERS } from '@utils/const';
+import { ALPHABETICAL_CHARS, DECIMAL_NUMBERS, PUNCTUATION_MARKS } from '@utils/const';
 
 export const morseChars =
-  '.- -... -.-. -.. . ..-. --. .... .. .--- -.- .-.. -- -. --- .--. --.- .-. ... - ..- ...- .-- -..- -.-- --.. .---- ..--- ...-- ....- ..... -.... --... ---.. ----. ----- /' as const;
+  '.- -... -.-. -.. . ..-. --. .... .. .--- -.- .-.. -- -. --- .--. --.- .-. ... - ..- ...- .-- -..- -.-- --.. .---- ..--- ...-- ....- ..... -.... --... ---.. ----. -----' as const;
+export const morsePunctMarks =
+  '.-... .----. .--.-. -.--.- -.--. ---... --..-- -...- -.-.-- .-.-.- -....- -..- .-.-. .-..-. ..--.. -..-.' as const;
 
 // Added the space character as equivalent to "/" in morse chars.
-export const englishCharsArr = (ALPHABETICAL_CHARS + DECIMAL_NUMBERS + ' ').split('');
-export const morseCharsArr = morseChars.split(' ');
-
-console.log(ALPHABETICAL_CHARS, DECIMAL_NUMBERS);
+export const englishCharsArr = (ALPHABETICAL_CHARS + DECIMAL_NUMBERS + PUNCTUATION_MARKS + ' ').split('');
+export const morseCharsArr = (morseChars + ' ' + morsePunctMarks + ' /').split(' ');
 
 export const englishToMorseMap = new Map(englishCharsArr.map((char, index) => [char, morseCharsArr[index]]));
 export const morseToEnglishMap = new Map(morseCharsArr.map((char, index) => [char, englishCharsArr[index]]));

--- a/src/actionHandlers/onMorseTranslate/helpers.ts
+++ b/src/actionHandlers/onMorseTranslate/helpers.ts
@@ -7,14 +7,14 @@ export const morseDecode = (morseText: string) =>
   morseText.split(' ').reduce((englishText, char) => englishText + morseToEnglishMap.get(char), '');
 
 export const filterAllowedMorseChars = (text: string) => {
-  const filteredTextArr = text.match(/[a-zA-Z0-9\s]+/);
+  const filteredTextArr = text.match(/[a-zA-Z0-9\s\p{P}=×+]+/u);
   const filteredText = filteredTextArr?.join().trim() ?? null;
 
   return filteredText;
 };
 
 const morseCodeRegex =
-  /^[.-]{1,5}(?:[ \t]+[.-]{1,5})*(?:[ \t]+[.-]{1,5}(?:[ \t]+[.-]{1,5})*)*(?:[ \t]*\/[ \t]*[.-]{1,5}(?:[ \t]+[.-]{1,5})*)*$/;
+  /^[.-]{1,6}(?:[ \t]+[.-]{1,6})*(?:[ \t]+[.-]{1,6}(?:[ \t]+[.-]{1,6})*)*(?:[ \t]*\/[ \t]*[.-]{1,6}(?:[ \t]+[.-]{1,6})*)*$/;
 export const checkIfMorseCode = (text: string) => morseCodeRegex.test(text);
 
 export const formatMorseCode = (morseCode: string) =>

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,2 +1,3 @@
 export const ALPHABETICAL_CHARS = 'abcdefghijklmnopqrstuvwxyz' as const;
 export const DECIMAL_NUMBERS = '1234567890' as const;
+export const PUNCTUATION_MARKS = '&\'@)(:,=!.-×+"?/' as const;


### PR DESCRIPTION
Added support for the following punctuation marks in the table except for '%' mark.
![image](https://github.com/user-attachments/assets/7ebf482e-4538-4c13-abda-7631c17dc765)

